### PR TITLE
Added support for Youtube url parameters

### DIFF
--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## 2.2.0 - 2024-03-01
+### Added
+- Added support for Youtube url parameters ([#1](https://github.com/statikbe/craft-video-parser/issues/1))
+
+
 ## 2.1.3 - 2023-12-8
 ### Fixed
 - Fixed an issue where inputting an unparseable url would throw an error instead of returning null

--- a/README.md
+++ b/README.md
@@ -12,9 +12,10 @@ It returns an object with the following properties:
 - Type (youtube or vimeo)
 - ID
 - embedSrc (specific to the type)
+- extraParts (url parameters separated by an &)
 
 Then you can create your own embed as you see fit.
 
 ````
-<iframe src="{{ video.embedSrc }}" frameborder="0" width="500" height="300"></iframe>
+<iframe src="{{ video.embedSrc }}{{ video.extraParts ? '?'~video.extraParts }}" frameborder="0" width="500" height="300"></iframe>
 ````

--- a/composer.json
+++ b/composer.json
@@ -2,16 +2,19 @@
   "name": "statikbe/craft-video-parser",
   "description": "Parse youtube & vimeo url's to make embeds",
   "type": "craft-plugin",
-  "version": "2.1.3",
+  "version": "2.2.0",
   "keywords": [
     "craft",
     "cms",
     "craftcms",
     "craft-plugin",
-    "video-embed"
+    "video-embed",
+    "video",
+    "youtube",
+    "vimeo"
   ],
   "support": {
-    "docs": "https://github.com/statikbe/craft-video-parser/blob/master/README.md",
+    "docs": "https://github.com/statikbe/craft-video-parser/blob/main/README.md",
     "issues": "https://github.com/statikbe/craft-video-parser/issues"
   },
   "license": "MIT",

--- a/src/models/Video.php
+++ b/src/models/Video.php
@@ -51,6 +51,13 @@ class Video extends Model
                     $this->id = $match[1];
                 }
 
+                if (str_contains($url, '&')) {
+                    $parts = explode('&', $url);
+                    array_shift($parts);
+                    $parts = preg_replace('/^t=(.*)s$/', "start=$1", $parts);
+                    $this->extraParts = implode("&", $parts);
+                }
+
                 $this->getEmbedSrc();
             } elseif (strpos($url, 'vimeo')) {
                 $this->type = Video::TYPE_VIMEO;


### PR DESCRIPTION
When adding a Youtube url with timestamp, the timestamp was left behind. Now all url parameters are added as extraParts.